### PR TITLE
Update hardcoded addresses

### DIFF
--- a/Il2CppDumper/Il2Cpp/Metadata.cs
+++ b/Il2CppDumper/Il2Cpp/Metadata.cs
@@ -149,7 +149,7 @@ namespace Il2CppDumper
             if (!stringCache.TryGetValue(index, out var result))
             {
                 //result = ReadStringToNull(header.stringOffset + index);
-                result = ReadStringToNull(0x9031b0 + index);
+                result = ReadStringToNull(0x9032D0 + index);
                 stringCache.Add(index, result);
             }
             return result;

--- a/Il2CppDumper/Program.cs
+++ b/Il2CppDumper/Program.cs
@@ -228,8 +228,8 @@ namespace Il2CppDumper
                         }
                     }
                     Console.WriteLine("baseadr: 0x" + baseaddr.ToString("x2"));
-                    var codeRegistration = baseaddr + 0x581A080;
-                    var metadataRegistration = baseaddr + 0x581A460;
+                    var codeRegistration = baseaddr + 0x581BD90;
+                    var metadataRegistration = baseaddr + 0x581C170;
                     il2Cpp.Init(codeRegistration, metadataRegistration);
                     return true;
                 }


### PR DESCRIPTION
addresses should work on the latest version as of me writing this. the UserAssembly.dll this is for has a sha-256 of `ED59352A24A105BFEDB75935CFF16F78A5C75570C14ED4B7A4330F94B00A4A75` on disk. the output looks sane enough, but i don't really have anything to compare against so i might've still gotten something wrong