### PR TITLE
 String literal decryption and other MetadataUsage stuff

### DIFF
--- a/Il2CppDumper/Il2Cpp/MetadataClass.cs
+++ b/Il2CppDumper/Il2Cpp/MetadataClass.cs
@@ -176,14 +176,14 @@ namespace Il2CppDumper
 
         public uint padding35;  //0xf0
         public uint padding36;
-        public uint padding37;
-        public uint padding38;
+        public uint metadataUsagePairsOffset;
+        public int metadataUsagePairsCount;
         public uint padding39;  //0x100
         public uint padding40;
         public uint padding41;
         public uint padding42;
-        public uint padding43;  //0x110
-        public uint padding44;
+        public uint fieldRefsOffset;  //0x110
+        public int fieldRefsCount;
 
         public uint eventsOffset; // 0x118
         public int eventsCount;
@@ -195,6 +195,13 @@ namespace Il2CppDumper
         public int parameterDefaultValuesCount;
         public uint fieldDefaultValuesOffset; // 0x138
         public int fieldDefaultValuesCount;
+
+        public uint padding45; // 0x140
+        public uint padding46;
+        public uint padding47;
+        public uint padding48;
+        public uint metadataUsageListsOffset; // 0x150
+        public int metadataUsageListsCount;
     }
 
     public class Il2CppImageDefinition
@@ -455,8 +462,8 @@ namespace Il2CppDumper
 
     public class Il2CppStringLiteral
     {
-        public uint length;
         public int dataIndex;
+        public uint length;
     }
 
     public class Il2CppParameterDefaultValue


### PR DESCRIPTION
my online classes are still boring, so here's another pull request.
this fully implements string literal decryption, and by having that, also implements the reading of the other MetadataUsage stuff for ScriptGenerator.cs.
again, this is relatively untested but the values from a generated stringliteral.json look sane to me.
also, you'll need to dump a decryption_blob.bin from the game. you can do this by searching for `23 24 65 48 51 2F AC 11 A1 5D 5D A3 63 AE 30 D1` in a full memory dump and dumping 0x5000 bytes from the start of the signature.
for archival purposes and actually making it possible to maintain this without having to reverse engineer everything again, here are the notes that i wrote for the string literal decryption process

```
find MetadataCache::GetStringLiteralFromIndex (used il2cpp output from https://gitlab.eecs.umich.edu/jsschaf/updated-gameday-mr/-/tree/master/app/Il2CppOutputProject/IL2CPP/libil2cpp/vm as a reference)
look for mystery call to a QWORD

.text:0000000184643643 loc_184643643:                          ; CODE XREF: MetadataCache__GetStringLiteralFromIndex+9C↑j
.text:0000000184643643                                         ; DATA XREF: MetadataCache__GetStringLiteralFromIndex:off_1846436BC↓o
.text:0000000184643643                 mov     rax, cs:s_StringLiteralTable ; jumptable 000000018464358C case 4
.text:000000018464364A                 lea     rbx, ds:0[rdx*8]
.text:0000000184643652                 mov     rax, [rbx+rax]
.text:0000000184643656                 test    rax, rax
.text:0000000184643659                 jnz     short loc_18464368F
.text:000000018464365B                 mov     rcx, cs:s_GlobalMetadata ; _QWORD
.text:0000000184643662                 lea     r8, [rsp+38h+arg_0] ; _QWORD
.text:0000000184643667                 mov     dword ptr [rsp+38h+arg_0], eax
.text:000000018464366B                 call    cs:LoadEncryptedStringLiteral  <<<<<<<<<<<<<<
.text:0000000184643671                 mov     edx, dword ptr [rsp+38h+arg_0]
.text:0000000184643675                 mov     rcx, rax
.text:0000000184643678                 call    il2cpp_string_new_len_0
.text:000000018464367D                 mov     rcx, cs:s_StringLiteralTable
.text:0000000184643684                 mov     [rbx+rcx], rax

this mystery function has its address set by (custom?) il2cpp export il2cpp_init_security
from dynamic analysis, this points into vmprotected UnityPlayer.dll
however, the code that gets called doesn't seem to be virtualized, just obfuscated

00007FFA4B33F1F0 | 55                       | push rbp                                | public string decryption function entry
00007FFA4B33F1F1 | 41:57                    | push r15                                |
00007FFA4B33F1F3 | 41:56                    | push r14                                |
00007FFA4B33F1F5 | 56                       | push rsi                                |
00007FFA4B33F1F6 | 57                       | push rdi                                |
00007FFA4B33F1F7 | 53                       | push rbx                                |
00007FFA4B33F1F8 | 48:83EC 18               | sub rsp,18                              |
00007FFA4B33F1FC | 48:8D6C24 10             | lea rbp,qword ptr ss:[rsp+10]           |
00007FFA4B33F201 | 4D:89C6                  | mov r14,r8                              |
00007FFA4B33F204 | 41:89D7                  | mov r15d,edx                            |
00007FFA4B33F207 | 48:89CB                  | mov rbx,rcx                             |
00007FFA4B33F20A | 48:8B05 7F627C01         | mov rax,qword ptr ds:[7FFA4CB05490]     |
00007FFA4B33F211 | 48:31E8                  | xor rax,rbp                             |
00007FFA4B33F214 | 48:8945 00               | mov qword ptr ss:[rbp],rax              |
00007FFA4B33F218 | C745 F8 93060000         | mov dword ptr ss:[rbp-8],693            |
00007FFA4B33F21F | 8B45 F8                  | mov eax,dword ptr ss:[rbp-8]            |
00007FFA4B33F222 | 89C1                     | mov ecx,eax                             |
00007FFA4B33F224 | F7D1                     | not ecx                                 |
00007FFA4B33F226 | 81E1 B11E7293            | and ecx,93721EB1                        |
00007FFA4B33F22C | 25 4EE18D6C              | and eax,6C8DE14E                        |
00007FFA4B33F231 | 09C1                     | or ecx,eax                              |
00007FFA4B33F233 | 81F1 66047293            | xor ecx,93720466                        |
00007FFA4B33F239 | 69C1 D9170000            | imul eax,ecx,17D9                       |
00007FFA4B33F23F | 05 5C8F34FE              | add eax,FE348F5C                        |
00007FFA4B33F244 | 89C1                     | mov ecx,eax                             |
00007FFA4B33F246 | F7D1                     | not ecx                                 |
00007FFA4B33F248 | 81E1 605A526C            | and ecx,6C525A60                        |
00007FFA4B33F24E | 25 9FA5AD93              | and eax,93ADA59F                        |
00007FFA4B33F253 | 09C1                     | or ecx,eax                              |
00007FFA4B33F255 | 81F1 545C526C            | xor ecx,6C525C54                        |
00007FFA4B33F25B | 31C0                     | xor eax,eax                             |
00007FFA4B33F25D | 81E9 1DEEFFFF            | sub ecx,FFFFEE1D                        |
00007FFA4B33F263 | 0F94C0                   | sete al                                 |
00007FFA4B33F266 | 48:8D0D 93817801         | lea rcx,qword ptr ds:[7FFA4CAC7400]     |
00007FFA4B33F26D | 48:8B04C1                | mov rax,qword ptr ds:[rcx+rax*8]        |
00007FFA4B33F271 | 48:05 7AADFFFF           | add rax,FFFFFFFFFFFFAD7A                |
00007FFA4B33F277 | FFE0                     | jmp rax                                 |
00007FFA4B33F279 | B8 10000000              | mov eax,10                              |
00007FFA4B33F27E | E8 2DED3701              | call unityplayer.7FFA4C6BDFB0           |
00007FFA4B33F283 | 48:29C4                  | sub rsp,rax                             |
00007FFA4B33F286 | 48:89E7                  | mov rdi,rsp                             |
00007FFA4B33F289 | B8 10000000              | mov eax,10                              |
00007FFA4B33F28E | E8 1DED3701              | call unityplayer.7FFA4C6BDFB0           |
00007FFA4B33F293 | 48:29C4                  | sub rsp,rax                             |
00007FFA4B33F296 | 48:89E2                  | mov rdx,rsp                             |
00007FFA4B33F299 | B8 10000000              | mov eax,10                              |
00007FFA4B33F29E | E8 0DED3701              | call unityplayer.7FFA4C6BDFB0           |
00007FFA4B33F2A3 | 48:29C4                  | sub rsp,rax                             |
00007FFA4B33F2A6 | 49:89E0                  | mov r8,rsp                              |
00007FFA4B33F2A9 | 48:893A                  | mov qword ptr ds:[rdx],rdi              |
00007FFA4B33F2AC | 48:83EC 20               | sub rsp,20                              |
00007FFA4B33F2B0 | B9 03000000              | mov ecx,3                               |
00007FFA4B33F2B5 | E8 46DC0000              | call unityplayer.7FFA4B34CF00           |
00007FFA4B33F2BA | 48:83C4 20               | add rsp,20                              |
00007FFA4B33F2BE | B8 20000000              | mov eax,20                              | 20:' '
00007FFA4B33F2C3 | E8 E8EC3701              | call unityplayer.7FFA4C6BDFB0           |
00007FFA4B33F2C8 | 48:29C4                  | sub rsp,rax                             |
00007FFA4B33F2CB | 48:89E2                  | mov rdx,rsp                             |
00007FFA4B33F2CE | B8 10000000              | mov eax,10                              |
00007FFA4B33F2D3 | E8 D8EC3701              | call unityplayer.7FFA4C6BDFB0           |
00007FFA4B33F2D8 | 48:29C4                  | sub rsp,rax                             |
00007FFA4B33F2DB | 48:89E6                  | mov rsi,rsp                             |
00007FFA4B33F2DE | 48:893A                  | mov qword ptr ds:[rdx],rdi              |
00007FFA4B33F2E1 | 48:895A 08               | mov qword ptr ds:[rdx+8],rbx            |
00007FFA4B33F2E5 | 44:897A 10               | mov dword ptr ds:[rdx+10],r15d          |
00007FFA4B33F2E9 | 4C:8972 18               | mov qword ptr ds:[rdx+18],r14           |
00007FFA4B33F2ED | 48:83EC 20               | sub rsp,20                              |
00007FFA4B33F2F1 | B9 13000000              | mov ecx,13                              |
00007FFA4B33F2F6 | 49:89F0                  | mov r8,rsi                              |
00007FFA4B33F2F9 | E8 E29A0000              | call unityplayer.7FFA4B348DE0           | actual decryption (pointer to string returned in r8)
00007FFA4B33F2FE | 48:83C4 20               | add rsp,20                              |
00007FFA4B33F302 | 48:8B36                  | mov rsi,qword ptr ds:[rsi]              |
00007FFA4B33F305 | 48:83EC 20               | sub rsp,20                              |
00007FFA4B33F309 | E8 52F7FFFF              | call unityplayer.7FFA4B33EA60           |
00007FFA4B33F30E | 48:83C4 20               | add rsp,20                              |
00007FFA4B33F312 | C745 FC F2150000         | mov dword ptr ss:[rbp-4],15F2           |
00007FFA4B33F319 | 8B45 FC                  | mov eax,dword ptr ss:[rbp-4]            |
00007FFA4B33F31C | 05 EF1A0000              | add eax,1AEF                            |
00007FFA4B33F321 | 89C1                     | mov ecx,eax                             |

the code in the call to 7FFA4B348DE0 is very scary, so i take the lazy route and set a memory write breakpoint on the string returned from it and have the game decrypt another string
doing this brings the disassembler to what seems like memcpy. walking up the stack to the caller shows a region of code that looks like this

00007FFA4B36DB0E | 48:8B05 73798501         | mov rax,qword ptr ds:[7FFA4CBC5488]     | encrypted header?? i have no clue where this come from
00007FFA4B36DB15 | 8B50 04                  | mov edx,dword ptr ds:[rax+4]            |
00007FFA4B36DB18 | 3351 0C                  | xor edx,dword ptr ds:[rcx+C]            |
00007FFA4B36DB1B | 8B58 14                  | mov ebx,dword ptr ds:[rax+14]           |
00007FFA4B36DB1E | 3359 14                  | xor ebx,dword ptr ds:[rcx+14]           |
00007FFA4B36DB21 | 48:63CA                  | movsxd rcx,edx                          |
00007FFA4B36DB24 | 4C:89EF                  | mov rdi,r13                             | r13 points to the decrypted global-metadata in memory
00007FFA4B36DB27 | 48:01CF                  | add rdi,rcx                             | rdi updates to point to string length and offset table here
00007FFA4B36DB2A | 49:63CE                  | movsxd rcx,r14d                         | r14 stores the string index
00007FFA4B36DB2D | 48:63D3                  | movsxd rdx,ebx                          |
00007FFA4B36DB30 | 49:01D5                  | add r13,rdx                             | r13 updates to point to the start of encrypted string data here
00007FFA4B36DB33 | 48:6314CF                | movsxd rdx,dword ptr ds:[rdi+rcx*8]     |
00007FFA4B36DB37 | 49:01D5                  | add r13,rdx                             | r13 updates to point to the encrypted string here
00007FFA4B36DB3A | 4C:8B70 18               | mov r14,qword ptr ds:[rax+18]           | r14 stores some decryption blob
00007FFA4B36DB3E | 48:89C8                  | mov rax,rcx                             |
00007FFA4B36DB41 | 31D2                     | xor edx,edx                             |
00007FFA4B36DB43 | BB 00280000              | mov ebx,2800                            |
00007FFA4B36DB48 | 48:F7F3                  | div rbx                                 | string index mod 0x2800 stored in rdx, rax not used
00007FFA4B36DB4B | 49:01D6                  | add r14,rdx                             | adds the string index to the decryption blob offset
00007FFA4B36DB4E | 48:89C8                  | mov rax,rcx                             |
00007FFA4B36DB51 | 48:C1E0 03               | shl rax,3                               |
00007FFA4B36DB55 | 48:89FB                  | mov rbx,rdi                             |
00007FFA4B36DB58 | 48:01C3                  | add rbx,rax                             |
00007FFA4B36DB5B | 48:83C3 04               | add rbx,4                               |
00007FFA4B36DB5F | 8B44CF 04                | mov eax,dword ptr ds:[rdi+rcx*8+4]      |
00007FFA4B36DB63 | 3D 00500000              | cmp eax,5000                            | skip if the string length is 0x5000 and higher
00007FFA4B36DB68 | 0F83 81000000            | jae unityplayer.7FFA4B36DBEF            |
00007FFA4B36DB6E | 45:31FF                  | xor r15d,r15d                           |
00007FFA4B36DB71 | 41:89C0                  | mov r8d,eax                             |
00007FFA4B36DB74 | 48:83EC 20               | sub rsp,20                              |
00007FFA4B36DB78 | 48:8D3D 11798501         | lea rdi,qword ptr ds:[7FFA4CBC5490]     |
00007FFA4B36DB7F | 48:89F9                  | mov rcx,rdi                             |
00007FFA4B36DB82 | 4C:89EA                  | mov rdx,r13                             |
00007FFA4B36DB85 | E8 E6393701              | call unityplayer.7FFA4C6E1570           | memcpy encrypted string data to a static buffer
00007FFA4B36DB8A | 48:83C4 20               | add rsp,20                              |
00007FFA4B36DB8E | 8B03                     | mov eax,dword ptr ds:[rbx]              |
00007FFA4B36DB90 | C60407 00                | mov byte ptr ds:[rdi+rax],0             | null terminate the output string
00007FFA4B36DB94 | 8B03                     | mov eax,dword ptr ds:[rbx]              | string decryption loop
00007FFA4B36DB96 | 41:39C7                  | cmp r15d,eax                            | eax stores the string length, r15d stores the current index
00007FFA4B36DB99 | 0F8D DC000000            | jge unityplayer.7FFA4B36DC7B            |
00007FFA4B36DB9F | 49:63FF                  | movsxd rdi,r15d                         |
00007FFA4B36DBA2 | 4C:8D05 E7788501         | lea r8,qword ptr ds:[7FFA4CBC5490]      |
00007FFA4B36DBA9 | 41:8A0C38                | mov cl,byte ptr ds:[r8+rdi]             |
00007FFA4B36DBAD | 48:8B05 D4788501         | mov rax,qword ptr ds:[7FFA4CBC5488]     |
00007FFA4B36DBB4 | 4C:8B48 18               | mov r9,qword ptr ds:[rax+18]            |
00007FFA4B36DBB8 | 48:89F8                  | mov rax,rdi                             |
00007FFA4B36DBBB | 48:05 00140000           | add rax,1400                            |
00007FFA4B36DBC1 | 31D2                     | xor edx,edx                             |
00007FFA4B36DBC3 | BE 00500000              | mov esi,5000                            |
00007FFA4B36DBC8 | 48:F7F6                  | div rsi                                 | (0x1400 + index) mod 0x5000 stored in rdx, rax not used
00007FFA4B36DBCB | 41:320C11                | xor cl,byte ptr ds:[r9+rdx]             |
00007FFA4B36DBCF | 48:89F8                  | mov rax,rdi                             |
00007FFA4B36DBD2 | 31D2                     | xor edx,edx                             |
00007FFA4B36DBD4 | BE 00280000              | mov esi,2800                            |
00007FFA4B36DBD9 | 48:F7F6                  | div rsi                                 | index mod 0x2800, rax not used
00007FFA4B36DBDC | 41:8A0416                | mov al,byte ptr ds:[r14+rdx]            |
00007FFA4B36DBE0 | 44:00F8                  | add al,r15b                             |
00007FFA4B36DBE3 | 30C1                     | xor cl,al                               |
00007FFA4B36DBE5 | 41:880C38                | mov byte ptr ds:[r8+rdi],cl             | decrypted byte stored
00007FFA4B36DBE9 | 41:83C7 01               | add r15d,1                              |
00007FFA4B36DBED | EB A5                    | jmp unityplayer.7FFA4B36DB94            |
00007FFA4B36DBEF | 83C0 01                  | add eax,1                               |
00007FFA4B36DBF2 | 89C1                     | mov ecx,eax                             |
00007FFA4B36DBF4 | 48:83EC 20               | sub rsp,20                              |
00007FFA4B36DBF8 | E8 63D04000              | call unityplayer.7FFA4B77AC60           |
00007FFA4B36DBFD | 48:83C4 20               | add rsp,20                              |
00007FFA4B36DC01 | 48:89C7                  | mov rdi,rax                             |
00007FFA4B36DC04 | 45:31E4                  | xor r12d,r12d                           |
00007FFA4B36DC07 | 44:8B3B                  | mov r15d,dword ptr ds:[rbx]             |
```
also, i manually cherrypicked this from my local fork so i might've missed something
